### PR TITLE
Require util, fixes 'ReferenceError: util is not defined'

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,5 @@
 var fs = require('fs'); 
+var util = require('util');
 
 function fileExists(filePath){
   try {


### PR DESCRIPTION
Fixes `ReferenceError: util is not defined` on line 17 when config.js `report_log: true`.

Apologies if I am misunderstanding something here... maybe there is a way to run the code without this require statement.